### PR TITLE
before_renderの中でhtml_optionsを生成する

### DIFF
--- a/app/assets/stylesheets/components/page/sample_component.css
+++ b/app/assets/stylesheets/components/page/sample_component.css
@@ -1,4 +1,4 @@
-@scope (.sample-component) {
+@scope (.sample-component) to ([data-scope]) {
   :scope {
     background-color: var(--color-background-default);
     color: var(--color-text-default);

--- a/app/assets/stylesheets/components/ui/button_component.css
+++ b/app/assets/stylesheets/components/ui/button_component.css
@@ -1,4 +1,4 @@
-@scope (button.button-component) {
+@scope (button.ui-button-component) {
   :scope {
     border: none;
     cursor: pointer;

--- a/app/assets/stylesheets/components/ui/button_component.css
+++ b/app/assets/stylesheets/components/ui/button_component.css
@@ -1,4 +1,4 @@
-@scope (button.ui-button-component) {
+@scope (button.ui-button-component) to ([data-scope]) {
   :scope {
     border: none;
     cursor: pointer;

--- a/app/components/ui/base.rb
+++ b/app/components/ui/base.rb
@@ -8,10 +8,21 @@ module Ui
       raise ArgumentError, "Invalid attribute value: '#{value}'. Must be one of #{white_list.join(', ')}."
     end
 
-    def build_html_options(html_options)
-      options = {}
-      options["data-scope"] = self.class.to_s.underscore.tr("/", "-").tr("_", "-")
-      options.merge(html_options)
+    def before_render
+      @html_options.merge!(default_data_scope)
+      add_default_class!(@html_options)
+    end
+
+    def default_data_scope
+      { "data-scope":  self.class.to_s.underscore.tr("/", "-").tr("_", "-") }
+    end
+
+    def add_default_class!(html_options)
+      if html_options[:class].nil?
+        html_options[:class] = []
+      end
+
+      html_options[:class].push(self.class.to_s.underscore.tr("/", "-").tr("_", "-"))
     end
   end
 end

--- a/app/components/ui/button_component.rb
+++ b/app/components/ui/button_component.rb
@@ -28,11 +28,10 @@ module Ui
     def build_html_options(html_options)
       options = html_options.merge({ class: button_classes })
       options.merge!({ type: @type.to_s })
-      super(options)
     end
 
     def button_classes
-      classes = [ "button-component" ]
+      classes = []
       classes.push(@category.to_s)
       classes.concat(@button_class)
       classes.push(@size.to_s)

--- a/test/components/ui/base_test.rb
+++ b/test/components/ui/base_test.rb
@@ -1,6 +1,19 @@
 require "test_helper"
 
 class BaseTest < ViewComponent::TestCase
+  # テスト用の継承クラス
+  class TestComponent < ::Ui::Base
+    def initialize
+      @html_options = { class: [ "test" ] }
+    end
+  end
+
+  class TestNoClassComponent < ::Ui::Base
+    def initialize
+      @html_options = {}
+    end
+  end
+
   # =====================================
   # #filter_attribute
   # =====================================
@@ -22,5 +35,35 @@ class BaseTest < ViewComponent::TestCase
     end
 
     assert_equal "Invalid attribute value: 'not_allowed'. Must be one of allow1, allow2.", error.message
+  end
+
+  # =====================================
+  # #before_render
+  # =====================================
+  test "継承先クラスでbefore_renderが正しいdata-scopeを設定すること" do
+    target = TestComponent.new
+
+    target.send(:before_render)
+
+    html_options = target.instance_variable_get(:@html_options)
+    assert_equal "base-test-test-component", html_options[:"data-scope"]
+  end
+
+  test "継承先クラスで独自のクラスが設定されている時、before_renderが正しいclassを追加すること" do
+    target = TestComponent.new
+
+    target.send(:before_render)
+
+    html_options = target.instance_variable_get(:@html_options)
+    assert_includes html_options[:class], "base-test-test-component"
+  end
+
+  test "継承先クラスで独自のクラスが設定されていない時、before_renderが正しいclassを追加すること" do
+    target = TestNoClassComponent.new
+
+    target.send(:before_render)
+
+    html_options = target.instance_variable_get(:@html_options)
+    assert_includes html_options[:class], "base-test-test-no-class-component"
   end
 end

--- a/test/components/ui/button_component_test.rb
+++ b/test/components/ui/button_component_test.rb
@@ -8,24 +8,24 @@ class ButtonComponentTest < ViewComponent::TestCase
     render_inline(Ui::ButtonComponent.new(category: :secondary, size: :medium, text: "test"))
 
     # button要素とクラスの確認
-    assert_selector("button.button-component.secondary.medium.default[data-scope=ui-button-component]")
+    assert_selector("button.ui-button-component.secondary.medium.default[data-scope=ui-button-component]")
 
-    # glass effectの要素がbutton-component直下にあることを確認
-    assert_selector(".button-component > .glass-effect")
-    assert_selector(".button-component > .glass-tint")
-    assert_selector(".button-component > .glass-shine")
-    assert_selector(".button-component > .glass-text", text: "test")
+    # glass effectの要素がui-button-component直下にあることを確認
+    assert_selector(".ui-button-component > .glass-effect")
+    assert_selector(".ui-button-component > .glass-tint")
+    assert_selector(".ui-button-component > .glass-shine")
+    assert_selector(".ui-button-component > .glass-text", text: "test")
   end
 
   test "渡したdisabledが反映されること" do
     render_inline(Ui::ButtonComponent.new(category: :secondary, size: :medium, text: "test", html_options: { disabled: true }))
 
-    assert_selector("button.button-component.secondary.medium.default[data-scope=ui-button-component][disabled]")
+    assert_selector("button.ui-button-component.secondary.medium.default[data-scope=ui-button-component][disabled]")
   end
 
   test "渡したクラスが反映されること" do
     render_inline(Ui::ButtonComponent.new(category: :secondary, size: :medium, text: "test", button_class: "added added2"))
 
-    assert_selector("button.button-component.secondary.medium.default.added.added2[data-scope=ui-button-component]")
+    assert_selector("button.ui-button-component.secondary.medium.default.added.added2[data-scope=ui-button-component]")
   end
 end


### PR DESCRIPTION
コンポーネントのcssクラス名やdata-scope属性の付与は基底クラスの中で行う方が規約を遵守させやすいので修正を行う。

修正前は、コンポーネントのクラス名を用意する、build_html_optionメソッドを呼び出してscopeを付与する、など把握しないといけない規約が多かったが、これからは@html_optionsを用意することだけを守れば良い