### PR TITLE
登録画面から認証メールと違うアドレスを保存できてしまう問題の修正(#32)

### DIFF
--- a/app/components/domain/user/database_authentication_registration_form_component.html.erb
+++ b/app/components/domain/user/database_authentication_registration_form_component.html.erb
@@ -13,13 +13,7 @@
 
     <div class="field">
       <%= f.label :email %>
-      <%= render Ui::EmailFieldComponent.new(
-        builder: f,
-        method: :email,
-        size: :medium,
-        variant: @form.errors[:email].any? ? :alert : :default,
-        html_options: { autocomplete: "email" }
-      ) %>
+      <p><%= @form.email %></p>
       <%= render Ui::FieldErrorsComponent.new(error_messages: @form.errors.full_messages_for(:email)) %>
     </div>
 

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -46,7 +46,8 @@ class User::RegistrationsController < Devise::ConfirmationsController
       return render :show, status: :unprocessable_entity
     end
 
-    form_params = params.require(:registration).permit(:user_name, :email, :password, :password_confirmation, :confirmation_token)
+    form_params = params.require(:registration).permit(:user_name, :password, :password_confirmation, :confirmation_token)
+    form_params[:email] = resource.email
     @form = User::DatabaseAuthenticationRegistrationForm.new(form_params)
 
     if @form.call

--- a/test/components/domain/user/database_authentication_registration_form_component_test.rb
+++ b/test/components/domain/user/database_authentication_registration_form_component_test.rb
@@ -30,7 +30,7 @@ class Domain::User::DatabaseAuthenticationRegistrationFormComponentTest < ViewCo
     assert_selector("input[type=text][name='registration[user_name]'][id='registration_user_name']")
   end
 
-  test "emailのラベルとinput要素があること" do
+  test "emailのラベルとテキスト表示があること" do
     form = User::DatabaseAuthenticationRegistrationForm.new(
       email: "test@example.com",
       confirmation_token: "token123"
@@ -42,7 +42,7 @@ class Domain::User::DatabaseAuthenticationRegistrationFormComponentTest < ViewCo
     ))
 
     assert_selector("label[for='registration_email']", text: "Email")
-    assert_selector("input[type=email][name='registration[email]'][id='registration_email'][value='test@example.com']")
+    assert_selector("p", text: "test@example.com")
   end
 
   test "passwordのラベルとinput要素があること" do

--- a/test/components/page/user/registrations/show_page_component_test.rb
+++ b/test/components/page/user/registrations/show_page_component_test.rb
@@ -54,7 +54,7 @@ class Page::User::Registrations::ShowPageComponentTest < ViewComponent::TestCase
       finish_user_registration_path: "/users/finish_registration"
     ))
 
-    assert_selector("input[name='registration[email]'][value='test@example.com']")
+    assert_selector("p", text: "test@example.com")
     assert_selector("input[name='registration[confirmation_token]'][value='token123']", visible: false)
   end
 end


### PR DESCRIPTION
close #32

ユーザーからは登録画面でメアドを変更できないようにする。Controller内で、paramsとresourceの認証済みemailを融合して登録処理を行う。