### PR TITLE
ConfirmationsController#show内でsuperの呼び出しをやめる(#37)

### DIFF
--- a/app/controllers/user/confirmations_controller.rb
+++ b/app/controllers/user/confirmations_controller.rb
@@ -16,9 +16,8 @@ class User::ConfirmationsController < Devise::ConfirmationsController
   end
 
   def show
-    super do
-      return redirect_to new_user_database_authentication_path(confirmation_token: resource.confirmation_token)
-    end
+    self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+    redirect_to new_user_database_authentication_path(confirmation_token: resource.confirmation_token)
   end
 
   def sent


### PR DESCRIPTION
close #37 

superを呼び出すと可読性が悪くなるので、「認証をしてユーザー登録画面にリダイレクト」というシンプルな処理をそのまま書くように変更