### PR TITLE
トークン認証失敗時にエラーメッセージを表示するように修正(#41)

### DIFF
--- a/app/components/page/user/confirmations/show_page_component.html.erb
+++ b/app/components/page/user/confirmations/show_page_component.html.erb
@@ -1,0 +1,25 @@
+<div <%= tag.attributes(@html_options) %> >
+  <%= render Ui::PanelComponent.new(size: :medium) do |panel| %>
+    <%- panel.with_panel_content do %>
+      <h2>メールアドレスの確認に失敗しました</h2>
+
+      <% if @resource.errors.any? %>
+        <%- @resource.errors.full_messages.each do |message| %>
+          <%= render Ui::FlashComponent.new(flash_type: :alert) do |c| %>
+            <%- c.with_flash_content do %>
+              <%= message %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <p>
+        確認メールを再送信する場合は、下記のリンクをクリックしてください。
+      </p>
+
+      <div class="actions">
+        <%= link_to "確認メールを再送信", new_confirmation_confirmation_path %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/page/user/confirmations/show_page_component.rb
+++ b/app/components/page/user/confirmations/show_page_component.rb
@@ -1,0 +1,11 @@
+module Page
+  module User
+    module Confirmations
+      class ShowPageComponent < Page::Base
+        def initialize(resource:)
+          @resource = resource
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/user/confirmations_controller.rb
+++ b/app/controllers/user/confirmations_controller.rb
@@ -17,7 +17,12 @@ class User::ConfirmationsController < Devise::ConfirmationsController
 
   def show
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
-    redirect_to new_user_database_authentication_path(confirmation_token: resource.confirmation_token)
+
+    if resource.errors.empty?
+      redirect_to new_user_database_authentication_path(confirmation_token: resource.confirmation_token)
+    else
+      respond_with(resource, status: :unprocessable_entity)
+    end
   end
 
   def sent

--- a/app/views/user/confirmations/show.html.erb
+++ b/app/views/user/confirmations/show.html.erb
@@ -1,0 +1,3 @@
+<%= render Page::User::Confirmations::ShowPageComponent.new(
+  resource: resource
+) %>


### PR DESCRIPTION
close #41

以下のように、不正なトークンでメール認証しようとした場合はエラーメッセージを表示するように修正。

格納されるエラー自体は、Deviseの`find_by_confirmation_token`の実行で格納されるもののみで、自分でカスタマイズして用意しているものはない。

<img width="1158" height="648" alt="image" src="https://github.com/user-attachments/assets/a1e3626c-edb7-45f7-ba44-622029626341" />
