### PR TITLE
EmailConfirmationFormのtrim_emailやEmail形式の確認をモデルに委譲(#33)

### DIFF
--- a/app/forms/user/email_confirmation_form.rb
+++ b/app/forms/user/email_confirmation_form.rb
@@ -1,25 +1,27 @@
 class User::EmailConfirmationForm < ApplicationForm
-  include ActiveModel::Validations::Callbacks
-
   attribute :email, :string
 
-  before_validation :trim_email
-
   validates :email, presence: true
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
+  validate :validate_user_confirmation
 
   # @rbs () -> bool
   def save
     return false unless valid?
 
-    user_confirmation = User::Confirmation.find_or_initialize_by(unconfirmed_email: email)
     user_confirmation.save
   end
 
   private
 
-  # @rbs () -> String
-  def trim_email
-    self.email = email&.strip
+  # @rbs () -> User::Confirmation
+  def user_confirmation
+    @user_confirmation ||= User::Confirmation.find_or_initialize_by(unconfirmed_email: email)
+  end
+
+  # @rbs () -> void
+  def validate_user_confirmation
+    return if email.blank?
+
+    validate_model(user_confirmation, attribute_map: { unconfirmed_email: :email })
   end
 end

--- a/app/models/user/confirmation.rb
+++ b/app/models/user/confirmation.rb
@@ -3,6 +3,8 @@ class User::Confirmation < ApplicationRecord
 
   before_validation :trim_email, :trim_unconfirmed_email
 
+  validates :unconfirmed_email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { unconfirmed_email.present? }
+
   private
 
   # @rbs () -> String?

--- a/sig/generated/forms/user/email_confirmation_form.rbs
+++ b/sig/generated/forms/user/email_confirmation_form.rbs
@@ -1,11 +1,12 @@
 class User::EmailConfirmationForm < ApplicationForm
-  include ActiveModel::Validations::Callbacks
-
   # @rbs () -> bool
   def save: () -> bool
 
   private
 
-  # @rbs () -> String
-  def trim_email: () -> String
+  # @rbs () -> User::Confirmation
+  def user_confirmation: () -> User::Confirmation
+
+  # @rbs () -> void
+  def validate_user_confirmation: () -> void
 end

--- a/sig/prototype/app/forms/user/email_confirmation_form.rbs
+++ b/sig/prototype/app/forms/user/email_confirmation_form.rbs
@@ -1,0 +1,3 @@
+class User::EmailConfirmationForm < ApplicationForm
+  @user_confirmation: untyped
+end

--- a/sig/rbs_rails/app/models/user.rbs
+++ b/sig/rbs_rails/app/models/user.rbs
@@ -36,6 +36,42 @@ class User < ::ApplicationRecord
 
     def clear_id_change: () -> void
 
+    def name: () -> ::String
+
+    def name=: (::String) -> ::String
+
+    def name?: () -> bool
+
+    def name_changed?: () -> bool
+
+    def name_change: () -> [ ::String?, ::String? ]
+
+    def name_will_change!: () -> void
+
+    def name_was: () -> ::String?
+
+    def name_previously_changed?: () -> bool
+
+    def name_previous_change: () -> ::Array[::String?]?
+
+    def name_previously_was: () -> ::String?
+
+    def name_before_last_save: () -> ::String?
+
+    def name_change_to_be_saved: () -> ::Array[::String?]?
+
+    def name_in_database: () -> ::String?
+
+    def saved_change_to_name: () -> ::Array[::String?]?
+
+    def saved_change_to_name?: () -> bool
+
+    def will_save_change_to_name?: () -> bool
+
+    def restore_name!: () -> void
+
+    def clear_name_change: () -> void
+
     def author: () -> bool
 
     def author=: (bool) -> bool
@@ -107,42 +143,6 @@ class User < ::ApplicationRecord
     def restore_created_at!: () -> void
 
     def clear_created_at_change: () -> void
-
-    def name: () -> ::String
-
-    def name=: (::String) -> ::String
-
-    def name?: () -> bool
-
-    def name_changed?: () -> bool
-
-    def name_change: () -> [ ::String?, ::String? ]
-
-    def name_will_change!: () -> void
-
-    def name_was: () -> ::String?
-
-    def name_previously_changed?: () -> bool
-
-    def name_previous_change: () -> ::Array[::String?]?
-
-    def name_previously_was: () -> ::String?
-
-    def name_before_last_save: () -> ::String?
-
-    def name_change_to_be_saved: () -> ::Array[::String?]?
-
-    def name_in_database: () -> ::String?
-
-    def saved_change_to_name: () -> ::Array[::String?]?
-
-    def saved_change_to_name?: () -> bool
-
-    def will_save_change_to_name?: () -> bool
-
-    def restore_name!: () -> void
-
-    def clear_name_change: () -> void
 
     def updated_at: () -> ::ActiveSupport::TimeWithZone
 

--- a/sig/rbs_rails/app/models/user/confirmation.rbs
+++ b/sig/rbs_rails/app/models/user/confirmation.rbs
@@ -37,42 +37,6 @@ class User < ::ApplicationRecord
 
       def clear_id_change: () -> void
 
-      def confirmation_sent_at: () -> ::ActiveSupport::TimeWithZone?
-
-      def confirmation_sent_at=: (::ActiveSupport::TimeWithZone?) -> ::ActiveSupport::TimeWithZone?
-
-      def confirmation_sent_at?: () -> bool
-
-      def confirmation_sent_at_changed?: () -> bool
-
-      def confirmation_sent_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
-
-      def confirmation_sent_at_will_change!: () -> void
-
-      def confirmation_sent_at_was: () -> ::ActiveSupport::TimeWithZone?
-
-      def confirmation_sent_at_previously_changed?: () -> bool
-
-      def confirmation_sent_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
-
-      def confirmation_sent_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
-
-      def confirmation_sent_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
-
-      def confirmation_sent_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
-
-      def confirmation_sent_at_in_database: () -> ::ActiveSupport::TimeWithZone?
-
-      def saved_change_to_confirmation_sent_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
-
-      def saved_change_to_confirmation_sent_at?: () -> bool
-
-      def will_save_change_to_confirmation_sent_at?: () -> bool
-
-      def restore_confirmation_sent_at!: () -> void
-
-      def clear_confirmation_sent_at_change: () -> void
-
       def confirmation_token: () -> ::String
 
       def confirmation_token=: (::String) -> ::String
@@ -145,41 +109,77 @@ class User < ::ApplicationRecord
 
       def clear_confirmed_at_change: () -> void
 
-      def created_at: () -> ::ActiveSupport::TimeWithZone
+      def confirmation_sent_at: () -> ::ActiveSupport::TimeWithZone?
 
-      def created_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
+      def confirmation_sent_at=: (::ActiveSupport::TimeWithZone?) -> ::ActiveSupport::TimeWithZone?
 
-      def created_at?: () -> bool
+      def confirmation_sent_at?: () -> bool
 
-      def created_at_changed?: () -> bool
+      def confirmation_sent_at_changed?: () -> bool
 
-      def created_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
+      def confirmation_sent_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
 
-      def created_at_will_change!: () -> void
+      def confirmation_sent_at_will_change!: () -> void
 
-      def created_at_was: () -> ::ActiveSupport::TimeWithZone?
+      def confirmation_sent_at_was: () -> ::ActiveSupport::TimeWithZone?
 
-      def created_at_previously_changed?: () -> bool
+      def confirmation_sent_at_previously_changed?: () -> bool
 
-      def created_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def confirmation_sent_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
 
-      def created_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
+      def confirmation_sent_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
 
-      def created_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
+      def confirmation_sent_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
 
-      def created_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def confirmation_sent_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
 
-      def created_at_in_database: () -> ::ActiveSupport::TimeWithZone?
+      def confirmation_sent_at_in_database: () -> ::ActiveSupport::TimeWithZone?
 
-      def saved_change_to_created_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def saved_change_to_confirmation_sent_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
 
-      def saved_change_to_created_at?: () -> bool
+      def saved_change_to_confirmation_sent_at?: () -> bool
 
-      def will_save_change_to_created_at?: () -> bool
+      def will_save_change_to_confirmation_sent_at?: () -> bool
 
-      def restore_created_at!: () -> void
+      def restore_confirmation_sent_at!: () -> void
 
-      def clear_created_at_change: () -> void
+      def clear_confirmation_sent_at_change: () -> void
+
+      def unconfirmed_email: () -> ::String?
+
+      def unconfirmed_email=: (::String?) -> ::String?
+
+      def unconfirmed_email?: () -> bool
+
+      def unconfirmed_email_changed?: () -> bool
+
+      def unconfirmed_email_change: () -> [ ::String?, ::String? ]
+
+      def unconfirmed_email_will_change!: () -> void
+
+      def unconfirmed_email_was: () -> ::String?
+
+      def unconfirmed_email_previously_changed?: () -> bool
+
+      def unconfirmed_email_previous_change: () -> ::Array[::String?]?
+
+      def unconfirmed_email_previously_was: () -> ::String?
+
+      def unconfirmed_email_before_last_save: () -> ::String?
+
+      def unconfirmed_email_change_to_be_saved: () -> ::Array[::String?]?
+
+      def unconfirmed_email_in_database: () -> ::String?
+
+      def saved_change_to_unconfirmed_email: () -> ::Array[::String?]?
+
+      def saved_change_to_unconfirmed_email?: () -> bool
+
+      def will_save_change_to_unconfirmed_email?: () -> bool
+
+      def restore_unconfirmed_email!: () -> void
+
+      def clear_unconfirmed_email_change: () -> void
 
       def email: () -> ::String?
 
@@ -217,41 +217,41 @@ class User < ::ApplicationRecord
 
       def clear_email_change: () -> void
 
-      def unconfirmed_email: () -> ::String?
+      def created_at: () -> ::ActiveSupport::TimeWithZone
 
-      def unconfirmed_email=: (::String?) -> ::String?
+      def created_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
 
-      def unconfirmed_email?: () -> bool
+      def created_at?: () -> bool
 
-      def unconfirmed_email_changed?: () -> bool
+      def created_at_changed?: () -> bool
 
-      def unconfirmed_email_change: () -> [ ::String?, ::String? ]
+      def created_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
 
-      def unconfirmed_email_will_change!: () -> void
+      def created_at_will_change!: () -> void
 
-      def unconfirmed_email_was: () -> ::String?
+      def created_at_was: () -> ::ActiveSupport::TimeWithZone?
 
-      def unconfirmed_email_previously_changed?: () -> bool
+      def created_at_previously_changed?: () -> bool
 
-      def unconfirmed_email_previous_change: () -> ::Array[::String?]?
+      def created_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
 
-      def unconfirmed_email_previously_was: () -> ::String?
+      def created_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
 
-      def unconfirmed_email_before_last_save: () -> ::String?
+      def created_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
 
-      def unconfirmed_email_change_to_be_saved: () -> ::Array[::String?]?
+      def created_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
 
-      def unconfirmed_email_in_database: () -> ::String?
+      def created_at_in_database: () -> ::ActiveSupport::TimeWithZone?
 
-      def saved_change_to_unconfirmed_email: () -> ::Array[::String?]?
+      def saved_change_to_created_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
 
-      def saved_change_to_unconfirmed_email?: () -> bool
+      def saved_change_to_created_at?: () -> bool
 
-      def will_save_change_to_unconfirmed_email?: () -> bool
+      def will_save_change_to_created_at?: () -> bool
 
-      def restore_unconfirmed_email!: () -> void
+      def restore_created_at!: () -> void
 
-      def clear_unconfirmed_email_change: () -> void
+      def clear_created_at_change: () -> void
 
       def updated_at: () -> ::ActiveSupport::TimeWithZone
 

--- a/sig/rbs_rails/app/models/user/database_authentication.rbs
+++ b/sig/rbs_rails/app/models/user/database_authentication.rbs
@@ -37,41 +37,41 @@ class User < ::ApplicationRecord
 
       def clear_id_change: () -> void
 
-      def created_at: () -> ::ActiveSupport::TimeWithZone
+      def user_id: () -> ::Integer
 
-      def created_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
+      def user_id=: (::Integer) -> ::Integer
 
-      def created_at?: () -> bool
+      def user_id?: () -> bool
 
-      def created_at_changed?: () -> bool
+      def user_id_changed?: () -> bool
 
-      def created_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
+      def user_id_change: () -> [ ::Integer?, ::Integer? ]
 
-      def created_at_will_change!: () -> void
+      def user_id_will_change!: () -> void
 
-      def created_at_was: () -> ::ActiveSupport::TimeWithZone?
+      def user_id_was: () -> ::Integer?
 
-      def created_at_previously_changed?: () -> bool
+      def user_id_previously_changed?: () -> bool
 
-      def created_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def user_id_previous_change: () -> ::Array[::Integer?]?
 
-      def created_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
+      def user_id_previously_was: () -> ::Integer?
 
-      def created_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
+      def user_id_before_last_save: () -> ::Integer?
 
-      def created_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def user_id_change_to_be_saved: () -> ::Array[::Integer?]?
 
-      def created_at_in_database: () -> ::ActiveSupport::TimeWithZone?
+      def user_id_in_database: () -> ::Integer?
 
-      def saved_change_to_created_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def saved_change_to_user_id: () -> ::Array[::Integer?]?
 
-      def saved_change_to_created_at?: () -> bool
+      def saved_change_to_user_id?: () -> bool
 
-      def will_save_change_to_created_at?: () -> bool
+      def will_save_change_to_user_id?: () -> bool
 
-      def restore_created_at!: () -> void
+      def restore_user_id!: () -> void
 
-      def clear_created_at_change: () -> void
+      def clear_user_id_change: () -> void
 
       def email: () -> ::String
 
@@ -145,6 +145,42 @@ class User < ::ApplicationRecord
 
       def clear_encrypted_password_change: () -> void
 
+      def created_at: () -> ::ActiveSupport::TimeWithZone
+
+      def created_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
+
+      def created_at?: () -> bool
+
+      def created_at_changed?: () -> bool
+
+      def created_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
+
+      def created_at_will_change!: () -> void
+
+      def created_at_was: () -> ::ActiveSupport::TimeWithZone?
+
+      def created_at_previously_changed?: () -> bool
+
+      def created_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def created_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
+
+      def created_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
+
+      def created_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def created_at_in_database: () -> ::ActiveSupport::TimeWithZone?
+
+      def saved_change_to_created_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def saved_change_to_created_at?: () -> bool
+
+      def will_save_change_to_created_at?: () -> bool
+
+      def restore_created_at!: () -> void
+
+      def clear_created_at_change: () -> void
+
       def updated_at: () -> ::ActiveSupport::TimeWithZone
 
       def updated_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
@@ -180,42 +216,6 @@ class User < ::ApplicationRecord
       def restore_updated_at!: () -> void
 
       def clear_updated_at_change: () -> void
-
-      def user_id: () -> ::Integer
-
-      def user_id=: (::Integer) -> ::Integer
-
-      def user_id?: () -> bool
-
-      def user_id_changed?: () -> bool
-
-      def user_id_change: () -> [ ::Integer?, ::Integer? ]
-
-      def user_id_will_change!: () -> void
-
-      def user_id_was: () -> ::Integer?
-
-      def user_id_previously_changed?: () -> bool
-
-      def user_id_previous_change: () -> ::Array[::Integer?]?
-
-      def user_id_previously_was: () -> ::Integer?
-
-      def user_id_before_last_save: () -> ::Integer?
-
-      def user_id_change_to_be_saved: () -> ::Array[::Integer?]?
-
-      def user_id_in_database: () -> ::Integer?
-
-      def saved_change_to_user_id: () -> ::Array[::Integer?]?
-
-      def saved_change_to_user_id?: () -> bool
-
-      def will_save_change_to_user_id?: () -> bool
-
-      def restore_user_id!: () -> void
-
-      def clear_user_id_change: () -> void
     end
 
     module GeneratedAssociationMethods

--- a/sig/rbs_rails/app/models/user/pending_sns_credential.rbs
+++ b/sig/rbs_rails/app/models/user/pending_sns_credential.rbs
@@ -37,149 +37,41 @@ class User < ::ApplicationRecord
 
       def clear_id_change: () -> void
 
-      def created_at: () -> ::ActiveSupport::TimeWithZone
+      def token: () -> ::String
 
-      def created_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
+      def token=: (::String) -> ::String
 
-      def created_at?: () -> bool
+      def token?: () -> bool
 
-      def created_at_changed?: () -> bool
+      def token_changed?: () -> bool
 
-      def created_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
+      def token_change: () -> [ ::String?, ::String? ]
 
-      def created_at_will_change!: () -> void
+      def token_will_change!: () -> void
 
-      def created_at_was: () -> ::ActiveSupport::TimeWithZone?
+      def token_was: () -> ::String?
 
-      def created_at_previously_changed?: () -> bool
+      def token_previously_changed?: () -> bool
 
-      def created_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def token_previous_change: () -> ::Array[::String?]?
 
-      def created_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
+      def token_previously_was: () -> ::String?
 
-      def created_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
+      def token_before_last_save: () -> ::String?
 
-      def created_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def token_change_to_be_saved: () -> ::Array[::String?]?
 
-      def created_at_in_database: () -> ::ActiveSupport::TimeWithZone?
+      def token_in_database: () -> ::String?
 
-      def saved_change_to_created_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def saved_change_to_token: () -> ::Array[::String?]?
 
-      def saved_change_to_created_at?: () -> bool
+      def saved_change_to_token?: () -> bool
 
-      def will_save_change_to_created_at?: () -> bool
+      def will_save_change_to_token?: () -> bool
 
-      def restore_created_at!: () -> void
+      def restore_token!: () -> void
 
-      def clear_created_at_change: () -> void
-
-      def email: () -> ::String
-
-      def email=: (::String) -> ::String
-
-      def email?: () -> bool
-
-      def email_changed?: () -> bool
-
-      def email_change: () -> [ ::String?, ::String? ]
-
-      def email_will_change!: () -> void
-
-      def email_was: () -> ::String?
-
-      def email_previously_changed?: () -> bool
-
-      def email_previous_change: () -> ::Array[::String?]?
-
-      def email_previously_was: () -> ::String?
-
-      def email_before_last_save: () -> ::String?
-
-      def email_change_to_be_saved: () -> ::Array[::String?]?
-
-      def email_in_database: () -> ::String?
-
-      def saved_change_to_email: () -> ::Array[::String?]?
-
-      def saved_change_to_email?: () -> bool
-
-      def will_save_change_to_email?: () -> bool
-
-      def restore_email!: () -> void
-
-      def clear_email_change: () -> void
-
-      def expires_at: () -> ::ActiveSupport::TimeWithZone
-
-      def expires_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
-
-      def expires_at?: () -> bool
-
-      def expires_at_changed?: () -> bool
-
-      def expires_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
-
-      def expires_at_will_change!: () -> void
-
-      def expires_at_was: () -> ::ActiveSupport::TimeWithZone?
-
-      def expires_at_previously_changed?: () -> bool
-
-      def expires_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
-
-      def expires_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
-
-      def expires_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
-
-      def expires_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
-
-      def expires_at_in_database: () -> ::ActiveSupport::TimeWithZone?
-
-      def saved_change_to_expires_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
-
-      def saved_change_to_expires_at?: () -> bool
-
-      def will_save_change_to_expires_at?: () -> bool
-
-      def restore_expires_at!: () -> void
-
-      def clear_expires_at_change: () -> void
-
-      def name: () -> ::String
-
-      def name=: (::String) -> ::String
-
-      def name?: () -> bool
-
-      def name_changed?: () -> bool
-
-      def name_change: () -> [ ::String?, ::String? ]
-
-      def name_will_change!: () -> void
-
-      def name_was: () -> ::String?
-
-      def name_previously_changed?: () -> bool
-
-      def name_previous_change: () -> ::Array[::String?]?
-
-      def name_previously_was: () -> ::String?
-
-      def name_before_last_save: () -> ::String?
-
-      def name_change_to_be_saved: () -> ::Array[::String?]?
-
-      def name_in_database: () -> ::String?
-
-      def saved_change_to_name: () -> ::Array[::String?]?
-
-      def saved_change_to_name?: () -> bool
-
-      def will_save_change_to_name?: () -> bool
-
-      def restore_name!: () -> void
-
-      def clear_name_change: () -> void
+      def clear_token_change: () -> void
 
       def provider: () -> ::String
 
@@ -217,42 +109,6 @@ class User < ::ApplicationRecord
 
       def clear_provider_change: () -> void
 
-      def token: () -> ::String
-
-      def token=: (::String) -> ::String
-
-      def token?: () -> bool
-
-      def token_changed?: () -> bool
-
-      def token_change: () -> [ ::String?, ::String? ]
-
-      def token_will_change!: () -> void
-
-      def token_was: () -> ::String?
-
-      def token_previously_changed?: () -> bool
-
-      def token_previous_change: () -> ::Array[::String?]?
-
-      def token_previously_was: () -> ::String?
-
-      def token_before_last_save: () -> ::String?
-
-      def token_change_to_be_saved: () -> ::Array[::String?]?
-
-      def token_in_database: () -> ::String?
-
-      def saved_change_to_token: () -> ::Array[::String?]?
-
-      def saved_change_to_token?: () -> bool
-
-      def will_save_change_to_token?: () -> bool
-
-      def restore_token!: () -> void
-
-      def clear_token_change: () -> void
-
       def uid: () -> ::String
 
       def uid=: (::String) -> ::String
@@ -288,6 +144,150 @@ class User < ::ApplicationRecord
       def restore_uid!: () -> void
 
       def clear_uid_change: () -> void
+
+      def email: () -> ::String
+
+      def email=: (::String) -> ::String
+
+      def email?: () -> bool
+
+      def email_changed?: () -> bool
+
+      def email_change: () -> [ ::String?, ::String? ]
+
+      def email_will_change!: () -> void
+
+      def email_was: () -> ::String?
+
+      def email_previously_changed?: () -> bool
+
+      def email_previous_change: () -> ::Array[::String?]?
+
+      def email_previously_was: () -> ::String?
+
+      def email_before_last_save: () -> ::String?
+
+      def email_change_to_be_saved: () -> ::Array[::String?]?
+
+      def email_in_database: () -> ::String?
+
+      def saved_change_to_email: () -> ::Array[::String?]?
+
+      def saved_change_to_email?: () -> bool
+
+      def will_save_change_to_email?: () -> bool
+
+      def restore_email!: () -> void
+
+      def clear_email_change: () -> void
+
+      def name: () -> ::String
+
+      def name=: (::String) -> ::String
+
+      def name?: () -> bool
+
+      def name_changed?: () -> bool
+
+      def name_change: () -> [ ::String?, ::String? ]
+
+      def name_will_change!: () -> void
+
+      def name_was: () -> ::String?
+
+      def name_previously_changed?: () -> bool
+
+      def name_previous_change: () -> ::Array[::String?]?
+
+      def name_previously_was: () -> ::String?
+
+      def name_before_last_save: () -> ::String?
+
+      def name_change_to_be_saved: () -> ::Array[::String?]?
+
+      def name_in_database: () -> ::String?
+
+      def saved_change_to_name: () -> ::Array[::String?]?
+
+      def saved_change_to_name?: () -> bool
+
+      def will_save_change_to_name?: () -> bool
+
+      def restore_name!: () -> void
+
+      def clear_name_change: () -> void
+
+      def expires_at: () -> ::ActiveSupport::TimeWithZone
+
+      def expires_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
+
+      def expires_at?: () -> bool
+
+      def expires_at_changed?: () -> bool
+
+      def expires_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
+
+      def expires_at_will_change!: () -> void
+
+      def expires_at_was: () -> ::ActiveSupport::TimeWithZone?
+
+      def expires_at_previously_changed?: () -> bool
+
+      def expires_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def expires_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
+
+      def expires_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
+
+      def expires_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def expires_at_in_database: () -> ::ActiveSupport::TimeWithZone?
+
+      def saved_change_to_expires_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def saved_change_to_expires_at?: () -> bool
+
+      def will_save_change_to_expires_at?: () -> bool
+
+      def restore_expires_at!: () -> void
+
+      def clear_expires_at_change: () -> void
+
+      def created_at: () -> ::ActiveSupport::TimeWithZone
+
+      def created_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
+
+      def created_at?: () -> bool
+
+      def created_at_changed?: () -> bool
+
+      def created_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
+
+      def created_at_will_change!: () -> void
+
+      def created_at_was: () -> ::ActiveSupport::TimeWithZone?
+
+      def created_at_previously_changed?: () -> bool
+
+      def created_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def created_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
+
+      def created_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
+
+      def created_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def created_at_in_database: () -> ::ActiveSupport::TimeWithZone?
+
+      def saved_change_to_created_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def saved_change_to_created_at?: () -> bool
+
+      def will_save_change_to_created_at?: () -> bool
+
+      def restore_created_at!: () -> void
+
+      def clear_created_at_change: () -> void
 
       def updated_at: () -> ::ActiveSupport::TimeWithZone
 

--- a/sig/rbs_rails/app/models/user/sns_credential.rbs
+++ b/sig/rbs_rails/app/models/user/sns_credential.rbs
@@ -37,77 +37,41 @@ class User < ::ApplicationRecord
 
       def clear_id_change: () -> void
 
-      def created_at: () -> ::ActiveSupport::TimeWithZone
+      def user_id: () -> ::Integer
 
-      def created_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
+      def user_id=: (::Integer) -> ::Integer
 
-      def created_at?: () -> bool
+      def user_id?: () -> bool
 
-      def created_at_changed?: () -> bool
+      def user_id_changed?: () -> bool
 
-      def created_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
+      def user_id_change: () -> [ ::Integer?, ::Integer? ]
 
-      def created_at_will_change!: () -> void
+      def user_id_will_change!: () -> void
 
-      def created_at_was: () -> ::ActiveSupport::TimeWithZone?
+      def user_id_was: () -> ::Integer?
 
-      def created_at_previously_changed?: () -> bool
+      def user_id_previously_changed?: () -> bool
 
-      def created_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def user_id_previous_change: () -> ::Array[::Integer?]?
 
-      def created_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
+      def user_id_previously_was: () -> ::Integer?
 
-      def created_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
+      def user_id_before_last_save: () -> ::Integer?
 
-      def created_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def user_id_change_to_be_saved: () -> ::Array[::Integer?]?
 
-      def created_at_in_database: () -> ::ActiveSupport::TimeWithZone?
+      def user_id_in_database: () -> ::Integer?
 
-      def saved_change_to_created_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+      def saved_change_to_user_id: () -> ::Array[::Integer?]?
 
-      def saved_change_to_created_at?: () -> bool
+      def saved_change_to_user_id?: () -> bool
 
-      def will_save_change_to_created_at?: () -> bool
+      def will_save_change_to_user_id?: () -> bool
 
-      def restore_created_at!: () -> void
+      def restore_user_id!: () -> void
 
-      def clear_created_at_change: () -> void
-
-      def email: () -> ::String
-
-      def email=: (::String) -> ::String
-
-      def email?: () -> bool
-
-      def email_changed?: () -> bool
-
-      def email_change: () -> [ ::String?, ::String? ]
-
-      def email_will_change!: () -> void
-
-      def email_was: () -> ::String?
-
-      def email_previously_changed?: () -> bool
-
-      def email_previous_change: () -> ::Array[::String?]?
-
-      def email_previously_was: () -> ::String?
-
-      def email_before_last_save: () -> ::String?
-
-      def email_change_to_be_saved: () -> ::Array[::String?]?
-
-      def email_in_database: () -> ::String?
-
-      def saved_change_to_email: () -> ::Array[::String?]?
-
-      def saved_change_to_email?: () -> bool
-
-      def will_save_change_to_email?: () -> bool
-
-      def restore_email!: () -> void
-
-      def clear_email_change: () -> void
+      def clear_user_id_change: () -> void
 
       def provider: () -> ::String
 
@@ -181,6 +145,78 @@ class User < ::ApplicationRecord
 
       def clear_uid_change: () -> void
 
+      def email: () -> ::String
+
+      def email=: (::String) -> ::String
+
+      def email?: () -> bool
+
+      def email_changed?: () -> bool
+
+      def email_change: () -> [ ::String?, ::String? ]
+
+      def email_will_change!: () -> void
+
+      def email_was: () -> ::String?
+
+      def email_previously_changed?: () -> bool
+
+      def email_previous_change: () -> ::Array[::String?]?
+
+      def email_previously_was: () -> ::String?
+
+      def email_before_last_save: () -> ::String?
+
+      def email_change_to_be_saved: () -> ::Array[::String?]?
+
+      def email_in_database: () -> ::String?
+
+      def saved_change_to_email: () -> ::Array[::String?]?
+
+      def saved_change_to_email?: () -> bool
+
+      def will_save_change_to_email?: () -> bool
+
+      def restore_email!: () -> void
+
+      def clear_email_change: () -> void
+
+      def created_at: () -> ::ActiveSupport::TimeWithZone
+
+      def created_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
+
+      def created_at?: () -> bool
+
+      def created_at_changed?: () -> bool
+
+      def created_at_change: () -> [ ::ActiveSupport::TimeWithZone?, ::ActiveSupport::TimeWithZone? ]
+
+      def created_at_will_change!: () -> void
+
+      def created_at_was: () -> ::ActiveSupport::TimeWithZone?
+
+      def created_at_previously_changed?: () -> bool
+
+      def created_at_previous_change: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def created_at_previously_was: () -> ::ActiveSupport::TimeWithZone?
+
+      def created_at_before_last_save: () -> ::ActiveSupport::TimeWithZone?
+
+      def created_at_change_to_be_saved: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def created_at_in_database: () -> ::ActiveSupport::TimeWithZone?
+
+      def saved_change_to_created_at: () -> ::Array[::ActiveSupport::TimeWithZone?]?
+
+      def saved_change_to_created_at?: () -> bool
+
+      def will_save_change_to_created_at?: () -> bool
+
+      def restore_created_at!: () -> void
+
+      def clear_created_at_change: () -> void
+
       def updated_at: () -> ::ActiveSupport::TimeWithZone
 
       def updated_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
@@ -216,42 +252,6 @@ class User < ::ApplicationRecord
       def restore_updated_at!: () -> void
 
       def clear_updated_at_change: () -> void
-
-      def user_id: () -> ::Integer
-
-      def user_id=: (::Integer) -> ::Integer
-
-      def user_id?: () -> bool
-
-      def user_id_changed?: () -> bool
-
-      def user_id_change: () -> [ ::Integer?, ::Integer? ]
-
-      def user_id_will_change!: () -> void
-
-      def user_id_was: () -> ::Integer?
-
-      def user_id_previously_changed?: () -> bool
-
-      def user_id_previous_change: () -> ::Array[::Integer?]?
-
-      def user_id_previously_was: () -> ::Integer?
-
-      def user_id_before_last_save: () -> ::Integer?
-
-      def user_id_change_to_be_saved: () -> ::Array[::Integer?]?
-
-      def user_id_in_database: () -> ::Integer?
-
-      def saved_change_to_user_id: () -> ::Array[::Integer?]?
-
-      def saved_change_to_user_id?: () -> bool
-
-      def will_save_change_to_user_id?: () -> bool
-
-      def restore_user_id!: () -> void
-
-      def clear_user_id_change: () -> void
     end
 
     module GeneratedAssociationMethods

--- a/test/models/user/confirmation_test.rb
+++ b/test/models/user/confirmation_test.rb
@@ -42,6 +42,29 @@ class User::ConfirmationTest < ActiveSupport::TestCase
     assert_equal "trimmed@example.com", confirmation.unconfirmed_email
   end
 
+  test "unconfirmed_emailが無効な形式の場合にバリデーションエラーになる" do
+    confirmation = User::Confirmation.new(unconfirmed_email: "invalid-email")
+
+    assert_not confirmation.valid?
+    assert_includes confirmation.errors[:unconfirmed_email], "は不正な値です"
+  end
+
+  test "unconfirmed_emailが有効な形式の場合にバリデーションが通る" do
+    confirmation = User::Confirmation.new(unconfirmed_email: "valid@example.com")
+
+    confirmation.valid?
+
+    assert_empty confirmation.errors[:unconfirmed_email]
+  end
+
+  test "unconfirmed_emailが空の場合はフォーマットバリデーションをスキップする" do
+    confirmation = User::Confirmation.new(unconfirmed_email: "")
+
+    confirmation.valid?
+
+    assert_not_includes confirmation.errors[:unconfirmed_email], "は不正な値です"
+  end
+
   test "confirmed_atが設定できる" do
     confirmation = User::Confirmation.new
     time = Time.current


### PR DESCRIPTION
close #33 