### PR TITLE
未ログイン時にいいねボタンを押すとログイン画面に遷移するように修正(#116)

### DIFF
--- a/app/components/domain/post/like_button_component.html.erb
+++ b/app/components/domain/post/like_button_component.html.erb
@@ -16,7 +16,7 @@
       <% end %>
     <% end %>
   <% else %>
-    <%= link_to login_path, class: "flex flex-row md:flex-col items-center gap-1 px-3 py-2 md:p-3 rounded-md border border-secondary bg-btn-secondary text-btn-secondary no-underline hover:bg-bg-like-hover transition-colors duration-200" do %>
+    <%= link_to login_path, data: { turbo_frame: "_top" }, class: "flex flex-row md:flex-col items-center gap-1 px-3 py-2 md:p-3 rounded-md border border-secondary bg-btn-secondary text-btn-secondary no-underline hover:bg-bg-like-hover transition-colors duration-200" do %>
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 md:w-6 md:h-6">
         <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
       </svg>

--- a/test/components/domain/post/like_button_component_test.rb
+++ b/test/components/domain/post/like_button_component_test.rb
@@ -18,6 +18,12 @@ class Domain::Post::LikeButtonComponentTest < ViewComponent::TestCase
     assert_selector("a[href='/login']")
   end
 
+  test "未ログイン時のリンクは画面遷移用の_top属性がついていること" do
+    render_inline(Domain::Post::LikeButtonComponent.new(post: @post, current_user: nil, id: "test"))
+
+    assert_selector("a[href='/login'][data-turbo-frame='_top']")
+  end
+
   test "未ログイン時にいいね数が表示されること" do
     PostLike.create!(user: @user, post: @post)
     render_inline(Domain::Post::LikeButtonComponent.new(post: @post, current_user: nil, id: "test"))


### PR DESCRIPTION
close #116 

turbo frameに変えたことで、未ログイン時にいいねボタンを押すと画面が切り替わらない問題が発生していた。

そのため、未ログイン時はturboに_top属性を付与して、画面全体が切り替わるようにする